### PR TITLE
Enforce callers pass a path for debugging purposes, and update ppx to…

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,7 @@
+set -e
+
+yarn build-ppx
+
+yarn build-lib
+
+yarn test

--- a/ppx_src/bin/Codecs.re
+++ b/ppx_src/bin/Codecs.re
@@ -31,29 +31,29 @@ let rec parameterizeCodecs = (typeArgs, encoderFunc, decoderFunc, generatorSetti
     )
 }
 
-and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, loc }) => {
+and generateConstrCodecs: (generatorSettings, Location.loc(Longident.t)) => (option(expression), option(expression)) = ({ doEncode, doDecode }, { Location.txt: identifier, loc }) => {
     open Longident;
 
     switch identifier {
         | Lident("string") => (
             doEncode ? Some([%expr Decco.stringToJson]) : None,
-            doDecode ? Some([%expr Decco.stringFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.stringFromJson([%e locToString(loc)])]) : None
         )
         | Lident("int") => (
             doEncode ? Some([%expr Decco.intToJson]) : None,
-            doDecode ? Some([%expr Decco.intFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.intFromJson([%e locToString(loc)])]) : None
         )
         | Lident("int64") => (
             doEncode ? Some([%expr Decco.int64ToJson]) : None,
-            doDecode ? Some([%expr Decco.int64FromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.int64FromJson([%e locToString(loc)])]) : None
         )
         | Lident("float") => (
             doEncode ? Some([%expr Decco.floatToJson]) : None,
-            doDecode ? Some([%expr Decco.floatFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.floatFromJson([%e locToString(loc)])]) : None
         )
         | Lident("bool") => (
             doEncode ? Some([%expr Decco.boolToJson]) : None,
-            doDecode ? Some([%expr Decco.boolFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.boolFromJson([%e locToString(loc)])]) : None
         )
         | Lident("unit") => (
             doEncode ? Some([%expr Decco.unitToJson]) : None,
@@ -61,11 +61,11 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
         )
         | Lident("array") => (
             doEncode ? Some([%expr Decco.arrayToJson]) : None,
-            doDecode ? Some([%expr Decco.arrayFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.arrayFromJson([%e locToString(loc)])]) : None
         )
         | Lident("list") => (
             doEncode ? Some([%expr Decco.listToJson]) : None,
-            doDecode ? Some([%expr Decco.listFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.listFromJson([%e locToString(loc)])]) : None
         )
         | Lident("option") => (
             doEncode ? Some([%expr Decco.optionToJson]) : None,
@@ -73,11 +73,11 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
         )
         | Ldot(Ldot(Lident("Belt"), "Result"), "t") => (
             doEncode ? Some([%expr Decco.resultToJson]) : None,
-            doDecode ? Some([%expr Decco.resultFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.resultFromJson([%e locToString(loc)])]) : None
         )
         | Ldot(Ldot(Lident("Js"), "Dict"), "t") => (
             doEncode ? Some([%expr Decco.dictToJson]) : None,
-            doDecode ? Some([%expr Decco.dictFromJson(Pervasives.__LOC__)]) : None
+            doDecode ? Some([%expr Decco.dictFromJson([%e locToString(loc)])]) : None
         )
         | Ldot(Ldot(Lident("Js"), "Json"), "t") => (
             doEncode ? Some([%expr (v) => v]) : None,
@@ -116,7 +116,7 @@ and generateCodecs = (
                 doDecode ? Some(
                     compositeCodecs
                     |> List.map(((_, d)) => BatOption.get(d))
-                    |> Tuple.generateDecoder)
+                    |> Tuple.generateDecoder(ptyp_loc))
                 : None
             );
         }

--- a/ppx_src/bin/Codecs.re
+++ b/ppx_src/bin/Codecs.re
@@ -37,23 +37,23 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
     switch identifier {
         | Lident("string") => (
             doEncode ? Some([%expr Decco.stringToJson]) : None,
-            doDecode ? Some([%expr Decco.stringFromJson]) : None
+            doDecode ? Some([%expr Decco.stringFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("int") => (
             doEncode ? Some([%expr Decco.intToJson]) : None,
-            doDecode ? Some([%expr Decco.intFromJson]) : None
+            doDecode ? Some([%expr Decco.intFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("int64") => (
             doEncode ? Some([%expr Decco.int64ToJson]) : None,
-            doDecode ? Some([%expr Decco.int64FromJson]) : None
+            doDecode ? Some([%expr Decco.int64FromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("float") => (
             doEncode ? Some([%expr Decco.floatToJson]) : None,
-            doDecode ? Some([%expr Decco.floatFromJson]) : None
+            doDecode ? Some([%expr Decco.floatFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("bool") => (
             doEncode ? Some([%expr Decco.boolToJson]) : None,
-            doDecode ? Some([%expr Decco.boolFromJson]) : None
+            doDecode ? Some([%expr Decco.boolFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("unit") => (
             doEncode ? Some([%expr Decco.unitToJson]) : None,
@@ -61,11 +61,11 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
         )
         | Lident("array") => (
             doEncode ? Some([%expr Decco.arrayToJson]) : None,
-            doDecode ? Some([%expr Decco.arrayFromJson]) : None
+            doDecode ? Some([%expr Decco.arrayFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("list") => (
             doEncode ? Some([%expr Decco.listToJson]) : None,
-            doDecode ? Some([%expr Decco.listFromJson]) : None
+            doDecode ? Some([%expr Decco.listFromJson(Pervasives.__LOC__)]) : None
         )
         | Lident("option") => (
             doEncode ? Some([%expr Decco.optionToJson]) : None,
@@ -73,11 +73,11 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
         )
         | Ldot(Ldot(Lident("Belt"), "Result"), "t") => (
             doEncode ? Some([%expr Decco.resultToJson]) : None,
-            doDecode ? Some([%expr Decco.resultFromJson]) : None
+            doDecode ? Some([%expr Decco.resultFromJson(Pervasives.__LOC__)]) : None
         )
         | Ldot(Ldot(Lident("Js"), "Dict"), "t") => (
             doEncode ? Some([%expr Decco.dictToJson]) : None,
-            doDecode ? Some([%expr Decco.dictFromJson]) : None
+            doDecode ? Some([%expr Decco.dictFromJson(Pervasives.__LOC__)]) : None
         )
         | Ldot(Ldot(Lident("Js"), "Json"), "t") => (
             doEncode ? Some([%expr (v) => v]) : None,

--- a/ppx_src/bin/Records.re
+++ b/ppx_src/bin/Records.re
@@ -46,9 +46,9 @@ let generateDictGets = (decls) => decls
     |> tupleOrSingleton(Exp.tuple);
 
 let generateErrorCase = ({ key }) => {
-    pc_lhs: [%pat? Belt.Result.Error(e : Decco.decodeError)],
+    pc_lhs: [%pat? Belt.Result.Error((e: Decco.decodeError))],
     pc_guard: None,
-    pc_rhs: [%expr Belt.Result.Error({ ...e, path: "." ++ [%e key] ++ e.path })]
+    pc_rhs: [%expr Belt.Result.Error({ ...e, path: "." ++ [%e key] ++ " " ++ e.path })],
 };
 
 let generateFinalRecordExpr = (decls) =>
@@ -85,7 +85,7 @@ let generateDecoder = (decls) => {
     [%expr (v) =>
         switch (Js.Json.classify(v)) {
             | Js.Json.JSONObject(dict) => [%e generateNestedSwitches(decls)]
-            | _ => Decco.error("Not an object", v)
+            | _ => Decco.error({ path: Pervasives.__LOC__, message: "Not an object", value: v })
         }
     ]
 };

--- a/ppx_src/bin/Structure.re
+++ b/ppx_src/bin/Structure.re
@@ -50,7 +50,7 @@ let generateCodecDecls = (typeName, paramNames, (encoder, decoder)) => {
     vbs;
 };
 
-let mapTypeDecl = (decl) => {
+let mapTypeDecl: type_declaration => list(value_binding)  = (decl) => {
     let { ptype_attributes, ptype_name: { txt: typeName },
           ptype_manifest, ptype_params, ptype_loc, ptype_kind } = decl;
 
@@ -65,11 +65,11 @@ let mapTypeDecl = (decl) => {
             )
             | (None, Ptype_variant(decls)) => generateCodecDecls(
                 typeName, getParamNames(ptype_params),
-                Variants.generateCodecs(generatorSettings, decls)
+                Variants.generateCodecs(ptype_loc, generatorSettings, decls)
             )
             | (None, Ptype_record(decls)) => generateCodecDecls(
                 typeName, getParamNames(ptype_params),
-                Records.generateCodecs(generatorSettings, decls)
+                Records.generateCodecs(ptype_loc, generatorSettings, decls)
             )
             | _ => fail(ptype_loc, "This type is not handled by decco")
         }

--- a/ppx_src/bin/Tuple.re
+++ b/ppx_src/bin/Tuple.re
@@ -62,8 +62,8 @@ let generateDecoder = (compositeDecoders) => {
 
     let outerSwitch = Exp.match([%expr Js.Json.classify(json)], [
         Exp.case(matchPattern, generateDecodeSwitch(compositeDecoders)),
-        Exp.case([%pat? Js.Json.JSONArray(_)], [%expr Decco.error("Incorrect cardinality", json)]),
-        Exp.case([%pat? _], [%expr Decco.error("Not a tuple", json)])
+        Exp.case([%pat? Js.Json.JSONArray(_)], [%expr Decco.error({ path: Pervasives.__LOC__, message: "Incorrect cardinality", value: json })]),
+        Exp.case([%pat? _], [%expr Decco.error({ path: Pervasives.__LOC__, message: "Not a tuple", value: json })])
     ]);
 
     [%expr (json) => [%e outerSwitch]];

--- a/ppx_src/bin/Tuple.re
+++ b/ppx_src/bin/Tuple.re
@@ -53,7 +53,7 @@ let generateDecodeSwitch = (compositeDecoders) => {
     |> Exp.match(decodeExpr);
 };
 
-let generateDecoder = (compositeDecoders) => {
+let generateDecoder = (loc: Location.t, compositeDecoders) => {
     let matchArrPattern = compositeDecoders
         |> List.mapi((i, _) => Pat.var(Location.mknoloc("v" ++ string_of_int(i))))
         |> Pat.array;
@@ -62,8 +62,8 @@ let generateDecoder = (compositeDecoders) => {
 
     let outerSwitch = Exp.match([%expr Js.Json.classify(json)], [
         Exp.case(matchPattern, generateDecodeSwitch(compositeDecoders)),
-        Exp.case([%pat? Js.Json.JSONArray(_)], [%expr Decco.error({ path: Pervasives.__LOC__, message: "Incorrect cardinality", value: json })]),
-        Exp.case([%pat? _], [%expr Decco.error({ path: Pervasives.__LOC__, message: "Not a tuple", value: json })])
+        Exp.case([%pat? Js.Json.JSONArray(_)], [%expr Decco.error({ path: [%e locToString(loc)], message: "Incorrect cardinality", value: json })]),
+        Exp.case([%pat? _], [%expr Decco.error({ path: [%e locToString(loc)], message: "Not a tuple", value: json })])
     ]);
 
     [%expr (json) => [%e outerSwitch]];

--- a/ppx_src/bin/Utils.re
+++ b/ppx_src/bin/Utils.re
@@ -100,3 +100,25 @@ let attrWarning = expr => {
     PStr([{pstr_desc: Pstr_eval(expr, []), pstr_loc: loc}]),
   );
 };
+
+let locToString = (loc: Location.t): expression => {
+  let line =
+    loc.loc_start.pos_lnum == loc.loc_end.pos_lnum
+      ? "line " ++ string_of_int(loc.loc_start.pos_lnum)
+      : "lines "
+        ++ string_of_int(loc.loc_start.pos_lnum)
+        ++ " - "
+        ++ string_of_int(loc.loc_end.pos_lnum);
+  Ast_convenience_406.str(
+    ~loc,
+    "File \""
+    ++ Filename.basename(loc.loc_start.pos_fname)
+    ++ "\", "
+    ++ line
+    ++ ", characters "
+    ++ string_of_int(loc.loc_start.pos_cnum - loc.loc_start.pos_bol)
+    ++ " - "
+    ++ string_of_int(loc.loc_end.pos_cnum - loc.loc_end.pos_bol),
+  );
+}
+

--- a/ppx_src/bin/Variants.re
+++ b/ppx_src/bin/Variants.re
@@ -108,7 +108,7 @@ let generateDecoderCase = (generatorSettings, { pcd_name: { txt: name }, pcd_arg
                 pc_guard: None,
                 pc_rhs: [%expr
                     (Js.Array.length(tagged) !== [%e argLen]) ?
-                        Decco.error("Invalid number of arguments to variant constructor", v)
+                        Decco.error({ path: Pervasives.__LOC__, message: "Invalid number of arguments to variant constructor", value: v })
                     :
                         [%e decoded]
                 ]
@@ -130,7 +130,7 @@ let generateCodecs = ({ doEncode, doDecode } as generatorSettings, constrDecls) 
     let decoderDefaultCase = {
         pc_lhs: [%pat? _],
         pc_guard: None,
-        pc_rhs: [%expr Decco.error("Invalid variant constructor", Belt.Array.getExn(jsonArr, 0))]
+        pc_rhs: [%expr Decco.error({ path: Pervasives.__LOC__, message: "Invalid variant constructor", value: Belt.Array.getExn(jsonArr, 0) })]
     };
 
     let decoder =
@@ -145,14 +145,14 @@ let generateCodecs = ({ doEncode, doDecode } as generatorSettings, constrDecls) 
                 Some([%expr (v) =>
                     switch (Js.Json.classify(v)) {
                         | Js.Json.JSONArray([||]) =>
-                            Decco.error("Expected variant, found empty array", v)
+                            Decco.error({ path: Pervasives.__LOC__, message: "Expected variant, found empty array", value: v })
 
                         | Js.Json.JSONArray(jsonArr) => {
                             let tagged = Js.Array.map(Js.Json.classify, jsonArr);
                             [%e decoderSwitch]
                         }
 
-                        | _ => Decco.error("Not a variant", v)
+                        | _ => Decco.error({ path: Pervasives.__LOC__, message: "Not a variant", value: v })
                     }
                 ]);
             }

--- a/test/__tests__/OpenBelt.re
+++ b/test/__tests__/OpenBelt.re
@@ -25,42 +25,42 @@ describe("variant", () => {
 
         describe("bad", () => {
             testBadDecode("non-variant", variant_decode, Js.Json.number(12.), {
-                path: "",
+                path: "File \"OpenBelt.re\", line 7, characters 9 - 51",
                 message: "Not a variant",
                 value: Js.Json.number(12.)
             });
 
             let json = {|["D"]|} |> Js.Json.parseExn;
             testBadDecode("bad constructor", variant_decode, json, {
-                path: "",
+                path: "File \"OpenBelt.re\", line 7, characters 9 - 51",
                 message: "Invalid variant constructor",
                 value: Js.Json.string("D")
             });
 
             let json = {|["A",1]|} |> Js.Json.parseExn;
             testBadDecode("too many arguments", variant_decode, json, {
-                path: "",
+                path: "File \"OpenBelt.re\", line 7, characters 24 - 25",
                 message: "Invalid number of arguments to variant constructor",
                 value: json
             });
 
             let json = {|[]|} |> Js.Json.parseExn;
             testBadDecode("no arguments", variant_decode, json, {
-                path: "",
+                path: "File \"OpenBelt.re\", line 7, characters 9 - 51",
                 message: "Expected variant, found empty array",
                 value: json
             });
 
             let json = {|["B"]|} |> Js.Json.parseExn;
             testBadDecode("not enough arguments", variant_decode, json, {
-                path: "",
+                path: "File \"OpenBelt.re\", line 7, characters 28 - 34",
                 message: "Invalid number of arguments to variant constructor",
                 value: json
             });
 
             let json = {|["B","oh"]|} |> Js.Json.parseExn;
             testBadDecode("invalid argument", variant_decode, json, {
-                path: "[0]",
+                path: "[0]File \"OpenBelt.re\", line 7, characters 30 - 33",
                 message: "Not a number",
                 value: Js.Json.string("oh")
             });

--- a/test/__tests__/test.re
+++ b/test/__tests__/test.re
@@ -7,7 +7,7 @@ open Belt.Result; */
 [@decco] type s = string;
 [@decco] type i = int;
 [@decco] type i64 = int64;
-[@decco] type i64Unsafe = [@decco.codec Decco.Codecs.int64Unsafe] int64;
+[@decco] type i64Unsafe = [@decco.codec Decco.Codecs.int64Unsafe(Pervasives.__LOC__)] int64;
 [@decco] type f = float;
 [@decco] type b = bool;
 [@decco] type u = unit;
@@ -676,7 +676,7 @@ describe("TestMod.varType", () => {
 
     let json = {|[5,"yay"]|} |> Js.Json.parseExn;
     testGoodDecode("varType_decode",
-        TestMod.varType_decode(Decco.intFromJson, Decco.stringFromJson),
+        TestMod.varType_decode(Decco.intFromJson(Pervasives.__LOC__), Decco.stringFromJson(Pervasives.__LOC__)),
         json, TestMod.mkVarType(5, "yay")
     );
 });

--- a/test/__tests__/test.re
+++ b/test/__tests__/test.re
@@ -90,7 +90,7 @@ describe("string", () => {
         testGoodDecode("good", s_decode, Js.Json.string("heyy"), "heyy");
 
         testBadDecode("bad", s_decode, Js.Json.number(12.), {
-            path: "",
+            path: "File \"test.re\", line 7, characters 18 - 24",
             message: "Not a string",
             value: Js.Json.number(12.)
         });
@@ -115,14 +115,14 @@ describe("int", () => {
         describe("bad", () => {
             let json = Js.Json.string("12.");
             testBadDecode("not a number", i_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 8, characters 18 - 21",
                 message: "Not a number",
                 value: json
             });
 
             let json = Js.Json.number(5.1);
             testBadDecode("not an int", i_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 8, characters 18 - 21",
                 message: "Not an integer",
                 value: json
             });
@@ -149,7 +149,7 @@ describe("int64", () => {
 
             let json = Js.Json.string("12.");
             testBadDecode("bad", i64_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 9, characters 20 - 25",
                 message: "Not a number",
                 value: json
             });
@@ -167,7 +167,7 @@ describe("int64", () => {
 
             let json = Js.Json.string("12.");
             testBadDecode("bad", i64Unsafe_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 10, characters 65-83",
                 message: "Not a number",
                 value: json
             });
@@ -191,7 +191,7 @@ describe("float", () => {
         testGoodDecode("good", f_decode, Js.Json.number(12.), 12.);
 
         testBadDecode("bad", f_decode, Js.Json.string("12."), {
-            path: "",
+            path: "File \"test.re\", line 11, characters 18 - 23",
             message: "Not a number",
             value: Js.Json.string("12.")
         });
@@ -210,7 +210,7 @@ describe("bool", () => {
         testGoodDecode("good", b_decode, Js.Json.boolean(false), false);
 
         testBadDecode("bad", b_decode, Js.Json.string("12."), {
-            path: "",
+            path: "File \"test.re\", line 12, characters 18 - 22",
             message: "Not a boolean",
             value: Js.Json.string("12.")
         });
@@ -241,21 +241,21 @@ describe("tuple", () => {
         describe("bad", () => {
             let json = Js.Json.number(12.);
             testBadDecode("non-array", t_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 14, characters 18 - 31",
                 message: "Not a tuple",
                 value: json
             });
 
             let json = {|[10]|} |> Js.Json.parseExn;
             testBadDecode("non-string", t_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 14, characters 18 - 31",
                 message: "Incorrect cardinality",
                 value: json
             });
 
             let json = {|[10,10]|} |> Js.Json.parseExn;
             testBadDecode("non-string", t_decode, json, {
-                path: "[1]",
+                path: "[1]File \"test.re\", line 14, characters 24 - 30",
                 message: "Not a string",
                 value: Js.Json.number(10.)
             });
@@ -275,7 +275,7 @@ describe("array", () => {
         describe("bad", () => {
             testBadDecode("non-array", a_decode(s_decode), Js.Json.number(12.), {
                 message: "Not an array",
-                path: "",
+                path: "File \"test.re\", line 15, characters 22 - 27",
                 value: Js.Json.number(12.),
             });
 
@@ -284,7 +284,7 @@ describe("array", () => {
                     Js.Json.string("str"), Js.Json.number(123.)
                 |]), {
                     message: "Not a string",
-                    path: "[1]",
+                    path: "[1]File \"test.re\", line 7, characters 18 - 24",
                     value: Js.Json.number(123.),
                 }
             );
@@ -302,9 +302,9 @@ describe("list", () => {
         testGoodDecode("good", l_decode(s_decode), json, ["10", "20"]);
 
         describe("bad", () => {
-            testBadDecode("non-array", l_decode(s_decode), Js.Json.number(12.), {
+            testBadDecode("non-list", l_decode(s_decode), Js.Json.number(12.), {
                 message: "Not an array",
-                path: "",
+                path: "File \"test.re\", line 16, characters 22 - 26",
                 value: Js.Json.number(12.),
             });
 
@@ -313,7 +313,7 @@ describe("list", () => {
                     Js.Json.string("str"), Js.Json.number(123.)
                 |]), {
                     message: "Not a string",
-                    path: "[1]",
+                    path: "[1]File \"test.re\", line 7, characters 18 - 24",
                     value: Js.Json.number(123.),
                 }
             );
@@ -349,7 +349,7 @@ describe("option", () => {
         });
 
         testBadDecode("bad", o_decode(s_decode), Js.Json.number(12.), {
-            path: "",
+            path: "File \"test.re\", line 7, characters 18 - 24",
             message: "Not a string",
             value: Js.Json.number(12.)
         });
@@ -377,42 +377,42 @@ describe("result", () => {
         describe("bad", () => {
             let json = Js.Json.number(12.);
             testBadDecode("not an array", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 18, characters 26 - 39",
                 message: "Not an array",
                 value: json
             });
 
             let json = "[]" |> Js.Json.parseExn;
             testBadDecode("length != 2", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 18, characters 26 - 39",
                 message: "Expected exactly 2 values in array",
                 value: json
             });
 
             let json = "[0,1]" |> Js.Json.parseExn;
             testBadDecode("constructor not a string", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 18, characters 26 - 39",
                 message: "Not a string",
                 value: Js.Json.number(0.)
             });
 
             let json = "[\"bad\",1]" |> Js.Json.parseExn;
             testBadDecode("unrecognized constructor", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 18, characters 26 - 39",
                 message: "Expected either \"Ok\" or \"Error\"",
                 value: Js.Json.string("bad")
             });
 
             let json = "[\"Ok\",1]" |> Js.Json.parseExn;
             testBadDecode("bad Ok decode", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 7, characters 18 - 24",
                 message: "Not a string",
                 value: Js.Json.number(1.)
             });
 
             let json = "[\"Error\",null]" |> Js.Json.parseExn;
             testBadDecode("bad Error decode", dec, json, {
-                path: "",
+                path: "File \"test.re\", line 8, characters 18 - 21",
                 message: "Not a number",
                 value: Js.Json.null
             });
@@ -448,7 +448,7 @@ describe("falseable", () => {
         });
 
         testBadDecode("bad", falseable_decode(s_decode), Js.Json.null, {
-            path: "",
+            path: "File \"test.re\", line 7, characters 18 - 24",
             message: "Not a string",
             value: Js.Json.null
         });
@@ -476,7 +476,7 @@ describe("simpleVar", () => {
         testGoodDecode("good", simpleVar_decode(s_decode), Js.Json.string("yeah"), "yeah");
 
         testBadDecode("bad", simpleVar_decode(s_decode), Js.Json.number(12.), {
-            path: "",
+            path: "File \"test.re\", line 7, characters 18 - 24",
             message: "Not a string",
             value: Js.Json.number(12.)
         });
@@ -495,14 +495,14 @@ describe("optionList", () => {
 
         describe("bad", () => {
             testBadDecode("non-array", optionList_decode, Js.Json.number(12.), {
-                path: "",
+                path: "File \"test.re\", line 16, characters 22 - 26",
                 message: "Not an array",
                 value: Js.Json.number(12.)
             });
 
             let json = {|[null, 3]|} |> Js.Json.parseExn;
             testBadDecode("non-string", optionList_decode, json, {
-                path: "[1]",
+                path: "[1]File \"test.re\", line 7, characters 18 - 24",
                 message: "Not a string",
                 value: Js.Json.number(3.)
             });
@@ -523,7 +523,7 @@ describe("dictInt", () => {
         describe("bad", () => {
             let badDict = {|{"foo":1,"bar":"baz"}|} |> Js.Json.parseExn;
             testBadDecode("mixed types", dictInt_decode, badDict, {
-                path: ".bar",
+                path: ".barFile \"test.re\", line 23, characters 26 - 29",
                 message: "Not a number",
                 value: Js.Json.string("baz")
             });
@@ -562,42 +562,42 @@ describe("variant", () => {
 
         describe("bad", () => {
             testBadDecode("non-variant", variant_decode, Js.Json.number(12.), {
-                path: "",
+                path: "File \"test.re\", line 24, characters 9 - 42",
                 message: "Not a variant",
                 value: Js.Json.number(12.)
             });
 
             let json = {|["D"]|} |> Js.Json.parseExn;
             testBadDecode("bad constructor", variant_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 24, characters 9 - 42",
                 message: "Invalid variant constructor",
                 value: Js.Json.string("D")
             });
 
             let json = {|["A",1]|} |> Js.Json.parseExn;
             testBadDecode("too many arguments", variant_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 24, characters 24 - 25",
                 message: "Invalid number of arguments to variant constructor",
                 value: json
             });
 
             let json = {|[]|} |> Js.Json.parseExn;
             testBadDecode("no arguments", variant_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 24, characters 9 - 42",
                 message: "Expected variant, found empty array",
                 value: json
             });
 
             let json = {|["B"]|} |> Js.Json.parseExn;
             testBadDecode("not enough arguments", variant_decode, json, {
-                path: "",
+                path: "File \"test.re\", line 24, characters 28 - 32",
                 message: "Invalid number of arguments to variant constructor",
                 value: json
             });
 
             let json = {|["B","oh"]|} |> Js.Json.parseExn;
             testBadDecode("invalid argument", variant_decode, json, {
-                path: "[0]",
+                path: "[0]File \"test.re\", line 8, characters 18 - 21",
                 message: "Not a number",
                 value: Js.Json.string("oh")
             });
@@ -623,21 +623,21 @@ describe("record", () => {
 
         describe("bad", () => {
             testBadDecode("non-object", record_decode, Js.Json.number(12.), {
-                path: "",
+                path: "File \"test.re\", lines 25 - 31, characters 9 - 1",
                 message: "Not an object",
                 value: Js.Json.number(12.)
             });
 
             let json = {|{"ya":100}|} |> Js.Json.parseExn;
             testBadDecode("missing field", record_decode, json, {
-                path: ".hey",
+                path: ".hey File \"test.re\", line 7, characters 18 - 24",
                 message: "Not a string",
                 value: Js.Json.null
             });
 
             let json = {|{"hey":9,"ya":10}|} |> Js.Json.parseExn;
             testBadDecode("invalid field type", record_decode, json, {
-                path: ".hey",
+                path: ".hey File \"test.re\", line 7, characters 18 - 24",
                 message: "Not a string",
                 value: Js.Json.number(9.)
             });
@@ -661,7 +661,7 @@ describe("Ldot", () => {
         testGoodDecode("good", dependentOnTestMod_decode, Js.Json.string("heyy"), TestMod.mkT("heyy"));
 
         testBadDecode("bad", dependentOnTestMod_decode, Js.Json.number(12.), {
-            path: "",
+            path: "File \"test.re\", line 50, characters 22 - 28",
             message: "Not a string",
             value: Js.Json.number(12.)
         });
@@ -694,7 +694,7 @@ describe("long path", () => {
     describe("bad", () => {
         let json = {|{"bigV":["V",[null,["","",1]]]}|} |> Js.Json.parseExn;
         testBadDecode("bad", bigR_decode, json, {
-            path: ".bigV[0][1][2]",
+            path: ".bigV [0][1][2]File \"test.re\", line 33, characters 41 - 47",
             message: "Not a string",
             value: Js.Json.number(1.)
         });


### PR DESCRIPTION
… generate better location info for decode failures.

So this is just a first pass at upgrading decco for better location information on decode errors. I haven't update the tests yet because I'm not sure how to fix this issue where it seems like the `Pervasives.__LOC__` calls are being evaluated when the ppx is run rather than printing that expression for bucklescript to compile.

If I someone can help me figure that part out then I can fix the tests and we all can go from this
`{path: "[0].id", message: "Not a int", value: nil}`
to something more along the lines of this...
`{path: "[0].id File "MyCustomRecord.re", line 8, characters 7-60", message: "Not an int", value: nil}`

This will also close https://github.com/reasonml-labs/decco/issues/54