### PR TITLE
Make postinstall hook compatible with Yarn 2 normalized shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf lib && bsb -clean-world && rm -rf ppx_src/_esy",
     "build-ppx": "cd ppx_src && esy",
     "watch-ppx": "cd ppx_src && esy dune build -w",
-    "postinstall": "[ ! -f package-links.json ] || ppl link-file"
+    "postinstall": "(test -e package-links.json && ppl link-file) || true"
   },
   "files": [
     "/bsconfig.json",


### PR DESCRIPTION
Hello! The package can’t be installed in a project using Yarn 2+ (aka Yarn Berry). The reason is that Yarn 2 brings its own [normalized shell](https://github.com/yarnpkg/berry/tree/master/packages/yarnpkg-shell) for `scripts` which is even simpler than “sh” but works the same way on all platforms. Namely, it does not support (intentionally) branch operations such as `[ ! -f file ] || blabla`.

Steps to reproduce:

```shell-session
$ yarn init .
...

$ yarn set version 2
$ yarn --version    
2.1.1

$ yarn add decco
➤ YN0000: ┌ Resolution step
➤ YN0002: │ decco-yarn-compat@workspace:. doesn't provide bs-platform@^6.0.0 || ^7.0.0 requested by decco@npm:1.2.1
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0013: │ decco@npm:1.2.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: └ Completed in 17.31s
➤ YN0000: ┌ Link step
➤ YN0007: │ decco@npm:1.2.1 [8d8c2] must be built because it never did before or the last one failed
➤ YN0009: │ decco@npm:1.2.1 [8d8c2] couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-955673fa/build.log)
➤ YN0009: │ decco@npm:1.2.1 [8d8c2] couldn't be built successfully (exit code 1, logs can be found here: /tmp/xfs-955673fa/build.log)
➤ YN0000: └ Completed in 0.27s
➤ YN0000: Failed with errors in 17.59s

$ cat /tmp/xfs-955673fa/build.log        
# This file contains the result of Yarn building a package (decco@virtual:8d8c27de4088db964c747b37e5c291207803800815d482f85d4d734fa5df41bb09d4c44759bb353c3cdae9d495cfa69e101599cb94ce620fdd317a35df8d01a6#npm:1.2.1)
# Script name: postinstall

Error: No file matches found: "!". Note: Glob patterns currently only support files that exist on the filesystem (Help Wanted)
    at B (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:438030)
    at async D (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:440819)
    at async b (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:441827)
    at async S (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:442158)
    at async F (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:443665)
    at async i.configuration.reduceHook.script (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:339490)
    at async /home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:339624
    at async a.mktempPromise (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:408207)
    at async Module.B (/home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:339248)
    at async /home/nkrkv/tmp/decco-yarn-compat/.yarn/releases/yarn-berry.js:2:302288
```

The solution is replacing branching statements with trivial `&&` and `||` which the normalized shell does support. While testing the solution I was surprised that the parens are necessary to make the standard idiom `check && if-ok || if-fail` work. That is, normalized shell requires `(check && if-ok) || if-fail`; otherwise it always fails if `check` fails.

The change makes Yarn 2 work but I didn’t test the actual effect while using the honest `ppl link-file` as I don’t quite understand your workflow. I see it ads some DX sugar but afraid I can’t reproduce the case :100: correctly. Albeit I see no reason why the behavior would change, who knows what can go wrong. I kindly ask you to ensure the things are actually keep working as before. Thanks!