### PR TITLE
Fix #24: Support for Js.Date.t

### DIFF
--- a/ppx_src/bin/Codecs.re
+++ b/ppx_src/bin/Codecs.re
@@ -83,6 +83,10 @@ and generateConstrCodecs = ({ doEncode, doDecode }, { Location.txt: identifier, 
             doEncode ? Some([%expr (v) => v]) : None,
             doDecode ? Some([%expr (v) => Belt.Result.Ok(v)]) : None,
         )
+        | Ldot(Ldot(Lident("Js"), "Date"), "t") => (
+            doEncode ? Some([%expr Decco.jsDateToJson]) : None,
+            doDecode ? Some([%expr Decco.jsDateFromJson]) : None
+        )
         | Lident(s) => (
             doEncode ? Some(Exp.ident(Ast_convenience.lid(s ++ Utils.encoderFuncSuffix))) : None,
             doDecode ? Some(Exp.ident(Ast_convenience.lid(s ++ Utils.decoderFuncSuffix))) : None,

--- a/src/Decco.re
+++ b/src/Decco.re
@@ -72,6 +72,24 @@ let boolFromJson = (j) =>
 let unitToJson = () => Js.Json.number(0.0);
 let unitFromJson = (_) => Belt.Result.Ok(());
 
+let jsDateToJson = (v: Js.Date.t) =>
+  Js.Date.toJSONUnsafe(v) |> Js.Json.string;
+let jsDateFromJson = j =>
+  try(
+    {
+      let date =
+        Js.Json.decodeString(j)->Belt.Option.getExn->Js.Date.fromString;
+      if (Js.Float.isNaN(Js.Date.getTime(date))) {
+        failwith("NaN");
+      } else {
+        Belt.Result.Ok(date);
+      };
+    }
+  ) {
+  | _ => Belt.Result.Error({path: "", message: "Not a date", value: j})
+  };
+
+
 let arrayToJson = (encoder, arr) =>
     arr
     |> Js.Array.map(encoder)
@@ -177,4 +195,5 @@ module Codecs {
     let list = (listToJson, listFromJson);
     let option = (optionToJson, optionFromJson);
     let unit = (unitToJson, unitFromJson);
+    let jsDate = (jsDateToJson, jsDateFromJson);
 };

--- a/test/__tests__/test.re
+++ b/test/__tests__/test.re
@@ -19,6 +19,7 @@ open Belt.Result; */
 [@decco] type d('v) = Js.Dict.t('v);
 [@decco] type simpleVar('a) = 'a;
 [@decco] type j = Js.Json.t;
+[@decco] type date = Js.Date.t;
 [@decco] type optionList = l(o(s));
 [@decco] type dictInt = d(int);
 [@decco] type variant = A | B(i) | C(i, s);
@@ -230,6 +231,35 @@ describe("unit", () => {
 
     testGoodDecode("u_decode", u_decode, Js.Json.number(0.), ());
 });
+
+describe("date", () => {
+  let asString = "2020-09-23T02:44:48.787Z";
+  let asDate = Js.Date.fromString(asString);
+
+  test("date_encode", () => {
+    let json = date_encode(asDate);
+
+    [@ocaml.warning "-4"]
+    (
+      switch (Js.Json.classify(json)) {
+      | Js.Json.JSONString(s) => expect(s) |> toBe(asString)
+      | _ => failwith("Not a JSONString")
+      }
+    );
+  });
+
+  describe("date_decode", () => {
+    testGoodDecode("good", date_decode, Js.Json.string(asString), asDate);
+
+    testBadDecode(
+      "bad",
+      date_decode,
+      Js.Json.string("heyy"),
+      {path: "", message: "Not a date", value: Js.Json.string("heyy")},
+    );
+  });
+});
+
 
 describe("tuple", () => {
     testEncode("t_encode", (10, "ten"), t_encode, {|[10,"ten"]|});


### PR DESCRIPTION
Fix #24. I'm using `Js.Date.toJSONUnsafe` for encoding following [bs-json](https://github.com/glennsl/bs-json/blob/522ecc90e075d1afdc4f26fd59c20b06fde376e4/src/Json_encode.ml#L14) but please let me know if you prefer to use `toISOString` instead.

Thanks a lot for the ppx!