### PR TITLE
Add postinstall script to remove the shell spawn overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Bucklescript PPX which generates JSON (de)serializers for user-defined types",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node postinstall.js",
     "test": "jest lib/js/test",
     "build-lib": "bsb -clean-world -make-world",
     "watch": "bsb -clean-world -make-world -w",
@@ -13,6 +14,7 @@
   },
   "files": [
     "/bsconfig.json",
+    "/postinstall.js",
     "/src",
     "/ppx",
     "/ppx-linux.exe",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,31 @@
+const path = require("path");
+const fs = require("fs");
+
+const installBinary = (binary) => {
+  const source = path.join(__dirname, binary);
+  if (fs.existsSync(source)) {
+    const target = path.join(__dirname, "ppx")
+    fs.renameSync(source, target)
+    // it should be executable in the bundle, but just in case
+    fs.chmodSync(target, 0777)
+  } else {
+    // assume we're in dev mode - nothing will break if the script
+    // isn't overwritten, it will just be slower
+  }
+}
+
+
+switch (process.platform) {
+  case "linux":
+    installBinary("ppx-linux.exe")
+    break;
+  case "darwin":
+    installBinary("ppx-osx.exe")
+    break;
+  case "win32":
+  default:
+    // This won't break the installation because the `ppx` shell script remains
+    // but that script will throw an error in this case anyway
+    console.warn(`No release available for "${process.platform}"`)
+    process.exit(1)
+}

--- a/ppx
+++ b/ppx
@@ -12,4 +12,7 @@ elif [ "$(uname)" = "Darwin" ]; then
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     # Run the Linux PPX
     $DIR/ppx-linux.exe $@
+else
+    echo "No release available for '$(uname)'"
+    exit 1
 fi


### PR DESCRIPTION
Thanks to #70 the ppx binaries can be used directly, so all the shell script does is platform detection. This is something we can do during installation to remove the shell spawn overhead when using the ppx.

On my big project, using a 2020 quad core Intel MBP, doing this manually reduces build times by 20-25%:
```
$ ./node_modules/.bin/bsb -clean && time ./node_modules/.bin/bsb
Cleaning... 3566 files.
bsb: [2065/2065] src/demo/re/DemoHugeDocumentTinymce.cmj

real	0m15.134s
user	0m43.146s
sys	0m46.942s

$ cp node_modules/decco/ppx-osx.exe node_modules/decco/ppx
$ ./node_modules/.bin/bsb -clean && time ./node_modules/.bin/bsb
Cleaning... 3566 files.
bsb: [2065/2065] src/demo/re/DemoHugeDocumentTinymce.cmj

real	0m11.980s
user	0m37.240s
sys	0m36.935s
```

The shell script is still there for installations that block `postinstall` so it should be a low risk change.