### PR TITLE
change optionFromJson to enable it to handle undefined values

### DIFF
--- a/src/Decco.re
+++ b/src/Decco.re
@@ -111,7 +111,7 @@ let optionToJson = (encoder, opt) =>
     };
 
 let optionFromJson = (decoder, json) =>
-    switch (Js.Null_undefined.return(json)->Js.Null_undefined.toOption) {
+    switch (Js.Null_undefined.return(json) |> Js.Null_undefined.toOption) {
         | None => Belt.Result.Ok(None)
         | Some(json) => decoder(json) |> Belt.Result.map(_, v => Some(v))
     };

--- a/src/Decco.re
+++ b/src/Decco.re
@@ -111,9 +111,9 @@ let optionToJson = (encoder, opt) =>
     };
 
 let optionFromJson = (decoder, json) =>
-    switch (Js.Json.decodeNull(json)) {
-        | Some(_) => Belt.Result.Ok(None)
-        | None => decoder(json) |> Belt.Result.map(_, v => Some(v))
+    switch (Js.Null_undefined.return(json)->Js.Null_undefined.toOption) {
+        | None => Belt.Result.Ok(None)
+        | Some(json) => decoder(json) |> Belt.Result.map(_, v => Some(v))
     };
 
 let resultToJson = (okEncoder, errorEncoder, result) =>
@@ -155,10 +155,10 @@ let dictFromJson = (decoder, json) =>
         ->Belt.Array.reduce(Ok(Js.Dict.empty()), (acc, (key, value)) =>
             switch (acc, decoder(value)) {
                 | (Error(_), _) => acc
-            
+
                 | (_, Error({ path } as error)) => Error({...error, path: "." ++ key ++ path})
-            
-                | (Ok(prev), Ok(newVal)) => 
+
+                | (Ok(prev), Ok(newVal)) =>
                     let () = prev->Js.Dict.set(key, newVal);
                     Ok(prev);
             }

--- a/test/__tests__/test.re
+++ b/test/__tests__/test.re
@@ -346,6 +346,7 @@ describe("option", () => {
     describe("o_decode", () => {
         describe("good", () => {
             testGoodDecode("null", o_decode(s_decode), Js.Json.null, None);
+            testGoodDecode("undefined", o_decode(s_decode), [%raw {|undefined|}], None);
             testGoodDecode("non-null", o_decode(s_decode), Js.Json.string("heyy"), Some("heyy"));
         });
 
@@ -702,6 +703,9 @@ describe("record", () => {
             testGoodDecode("base case", record_decode, json, { hey: "hey", opt: Some(100), o: Some(99), f: 1.5, otherKey: "!" });
 
             let json = {|{"hey":"hey","other_key":"!"}|} |> Js.Json.parseExn;
+            testGoodDecode("missing optional", record_decode, json, { hey: "hey", opt: None, o: None, f: 1.0, otherKey: "!" });
+
+            let json: Js.Json.t = [%raw {|{"hey":"hey","other_key":"!","opt": undefined}|}]
             testGoodDecode("missing optional", record_decode, json, { hey: "hey", opt: None, o: None, f: 1.0, otherKey: "!" });
         });
 

--- a/test/__tests__/test.re
+++ b/test/__tests__/test.re
@@ -706,7 +706,7 @@ describe("record", () => {
             testGoodDecode("missing optional", record_decode, json, { hey: "hey", opt: None, o: None, f: 1.0, otherKey: "!" });
 
             let json: Js.Json.t = [%raw {|{"hey":"hey","other_key":"!","opt": undefined}|}]
-            testGoodDecode("missing optional", record_decode, json, { hey: "hey", opt: None, o: None, f: 1.0, otherKey: "!" });
+            testGoodDecode("optional field set to undefined", record_decode, json, { hey: "hey", opt: None, o: None, f: 1.0, otherKey: "!" });
         });
 
         describe("bad", () => {


### PR DESCRIPTION
Changes decco's `optionFromJson` so that it treats both `null` and `undefined` as `None`. This makes it much easier to deal with objects coming in from JS code which might use `undefined` or have the field missing entirely.