### PR TITLE
Support spreading in record types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.cmx
 *.cmxs
 *.cmxa
+*.cmt
+*.cmj
 
 # ocamlbuild working directory
 _build/

--- a/bin/preview-ppx-watch.sh
+++ b/bin/preview-ppx-watch.sh
@@ -7,10 +7,10 @@ if [ -z "$file_path" ]; then
 	exit 1
 fi
 
-if ! command -v watch &>/dev/null; then
-	echo "watch command not found. Please install it using Homebrew:"
-	echo "brew install watch"
+if ! command -v viddy &>/dev/null; then
+	echo "viddy command not found. Please install it using Homebrew:"
+	echo "brew install viddy"
 	exit 1
 fi
 
-/opt/homebrew/bin/watch -n 1 -c -d "./node_modules/rescript/bsc -ppx ./ppx -bs-no-builtin-ppx -reprint-source $file_path"
+/opt/homebrew/bin/viddy -n 1 -c -d "./node_modules/rescript/bsc -ppx ./ppx -bs-no-builtin-ppx -reprint-source $file_path"

--- a/ppx_src/src/BatOption.ml
+++ b/ppx_src/src/BatOption.ml
@@ -1,4 +1,4 @@
 let get = function
   | None -> failwith "Expected Some. got None"
-  | ((Some v) [@explicit_arity]) -> v
-let some v = (Some v [@explicit_arity])
+  | Some v -> v
+let some v = Some v

--- a/ppx_src/src/Codecs.ml
+++ b/ppx_src/src/Codecs.ml
@@ -29,148 +29,158 @@ let rec parameterizeCodecs typeArgs encoderFunc decoderFunc encodeDecodeFlags =
       |> Exp.apply ~attrs:uncurriedApplicationAttrs decoderFunc
       |> BatOption.some )
 
-and generateConstrCodecs {doEncode; doDecode} {Location.txt = identifier; loc} =
+(* The optional expressions that are returned from this function should be codec functions themselves.
+   Not bindings. The receiver will invoke them with the value when it decides to. *)
+and generateCodecsFromTypeConstructor {doEncode; doDecode}
+    {Location.txt = identifier; loc} =
   let open Longident in
   match identifier with
-  | ((Lident "string") [@explicit_arity]) ->
+  | Lident "string" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.stringToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.stringToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.stringFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.stringFromJson]
       | false -> None )
-  | ((Lident "int") [@explicit_arity]) ->
+  | Lident "int" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.intToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.intToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.intFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.intFromJson]
       | false -> None )
-  | ((Lident "int64") [@explicit_arity]) ->
+  | Lident "int64" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.int64ToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.int64ToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.int64FromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.int64FromJson]
       | false -> None )
-  | ((Lident "float") [@explicit_arity]) ->
+  | Lident "float" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.floatToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.floatToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.floatFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.floatFromJson]
       | false -> None )
-  | ((Lident "bool") [@explicit_arity]) ->
+  | Lident "bool" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.boolToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.boolToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.boolFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.boolFromJson]
       | false -> None )
-  | ((Lident "unit") [@explicit_arity]) ->
+  | Lident "unit" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.unitToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.unitToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.unitFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.unitFromJson]
       | false -> None )
-  | ((Lident "array") [@explicit_arity]) ->
+  | Lident "array" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.arrayToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.arrayToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.arrayFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.arrayFromJson]
       | false -> None )
-  | ((Lident "list") [@explicit_arity]) ->
+  | Lident "list" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.listToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.listToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.listFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.listFromJson]
       | false -> None )
-  | ((Lident "option") [@explicit_arity]) ->
+  | Lident "option" ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.optionToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.optionToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.optionFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.optionFromJson]
       | false -> None )
-  | ((Ldot
-       ( ((Ldot (((Lident "Belt") [@explicit_arity]), "Result"))
-         [@explicit_arity]),
-         "t" ))
-  [@explicit_arity]) ->
+  | Ldot (Ldot (Lident "Belt", "Result"), "t") ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.resultToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.resultToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.resultFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.resultFromJson]
       | false -> None )
-  | ((Ldot
-       ( ((Ldot (((Lident "Js") [@explicit_arity]), "Dict")) [@explicit_arity]),
-         "t" ))
-  [@explicit_arity]) ->
+  | Ldot (Ldot (Lident "Js", "Dict"), "t") ->
     ( (match doEncode with
-      | true -> Some [%expr Decco.dictToJson] [@explicit_arity]
+      | true -> Some [%expr Decco.dictToJson]
       | false -> None),
       match doDecode with
-      | true -> Some [%expr Decco.dictFromJson] [@explicit_arity]
+      | true -> Some [%expr Decco.dictFromJson]
       | false -> None )
-  | ((Ldot
-       ( ((Ldot (((Lident "Js") [@explicit_arity]), "Json")) [@explicit_arity]),
-         "t" ))
-  [@explicit_arity]) ->
+  | Ldot (Ldot (Lident "Js", "Json"), "t") ->
     ( (match doEncode with
       | true ->
         Some
           (Utils.wrapFunctionExpressionForUncurrying ~arity:1
              [%expr fun v -> v])
-        [@explicit_arity]
       | false -> None),
       match doDecode with
       | true ->
         Some
           (Utils.wrapFunctionExpressionForUncurrying ~arity:1
-             [%expr fun v -> (Belt.Result.Ok v [@explicit_arity])])
-        [@explicit_arity]
+             [%expr fun v -> Belt.Result.Ok v])
       | false -> None )
-  | ((Lident s) [@explicit_arity]) ->
+  | Lident s ->
+    (* Lident is such an abstract name. This is when we're handling a reference to something
+       that isn't some special syntactic construct. For example, in type blah = string, the
+       'string' part is a Lident. Same thing if we had `type blah = user`. The `user` part
+        would be a Lident. *)
     ( (match doEncode with
-      | true ->
-        Some (makeIdentExpr (s ^ Utils.encoderFuncSuffix)) [@explicit_arity]
+      | true -> Some (makeIdentExpr (s ^ Utils.encoderFuncSuffix))
       | false -> None),
       match doDecode with
-      | true ->
-        Some (makeIdentExpr (s ^ Utils.decoderFuncSuffix)) [@explicit_arity]
+      | true -> Some (makeIdentExpr (s ^ Utils.decoderFuncSuffix))
       | false -> None )
-  | ((Ldot (left, right)) [@explicit_arity]) ->
+  | Ldot (left, right) ->
     ( (match doEncode with
       | true ->
         Some
-          (Exp.ident
-             (mknoloc
-                (Ldot (left, right ^ Utils.encoderFuncSuffix) [@explicit_arity])))
-        [@explicit_arity]
+          (Exp.ident (mknoloc (Ldot (left, right ^ Utils.encoderFuncSuffix))))
       | false -> None),
       match doDecode with
       | true ->
         Some
-          (Exp.ident
-             (mknoloc
-                (Ldot (left, right ^ Utils.decoderFuncSuffix) [@explicit_arity])))
-        [@explicit_arity]
+          (Exp.ident (mknoloc (Ldot (left, right ^ Utils.decoderFuncSuffix))))
       | false -> None )
-  | ((Lapply (_, _)) [@explicit_arity]) ->
-    fail loc "Lapply syntax not yet handled by decco"
+  | Lapply (_, _) -> fail loc "Lapply syntax not yet handled by decco"
 
+(* This gets called when a type declaration has a @decco.codec decorator with
+   custom functions. *)
+and generateCustomCodecs attribute {doEncode; doDecode} =
+  let expr = Utils.getExpressionFromPayload attribute in
+  ( (match doEncode with
+    | true ->
+      Some
+        [%expr
+          let e, _ = [%e expr] in
+          e]
+    | false -> None),
+    match doDecode with
+    | true ->
+      Some
+        [%expr
+          let _, d = [%e expr] in
+          d]
+    | false -> None )
+
+(* This is a recursive function that operates on core types to make generators. core types
+   might not be what you think, like strings and ints. Core types as far as the AST is
+   concerned are, I think, basic elements of the parse tree. So this is going to be called
+   not only with type declarations like 'type foo = string', but also with smaller parts of
+   that declaration, like just 'string' *)
 and generateCodecs ({doEncode; doDecode} as encodeDecodeFlags)
     {ptyp_desc; ptyp_loc; ptyp_attributes} =
   match ptyp_desc with
   | Ptyp_any -> fail ptyp_loc "Can't generate codecs for `any` type"
-  | ((Ptyp_arrow (_, _, _)) [@explicit_arity]) ->
+  | Ptyp_arrow (_, _, _) ->
     fail ptyp_loc "Can't generate codecs for function type"
   | Ptyp_package _ -> fail ptyp_loc "Can't generate codecs for module type"
-  | ((Ptyp_tuple types) [@explicit_arity]) -> (
+  | Ptyp_tuple types -> (
     let compositeCodecs = List.map (generateCodecs encodeDecodeFlags) types in
     ( (match doEncode with
       | true ->
@@ -178,7 +188,6 @@ and generateCodecs ({doEncode; doDecode} as encodeDecodeFlags)
           (compositeCodecs
           |> List.map (fun (e, _) -> BatOption.get e)
           |> Tuple.generateEncoder)
-        [@explicit_arity]
       | false -> None),
       match doDecode with
       | true ->
@@ -186,42 +195,42 @@ and generateCodecs ({doEncode; doDecode} as encodeDecodeFlags)
           (compositeCodecs
           |> List.map (fun (_, d) -> BatOption.get d)
           |> Tuple.generateDecoder)
-        [@explicit_arity]
       | false -> None ))
-  | ((Ptyp_var s) [@explicit_arity]) ->
+  | Ptyp_var s ->
+    (* In this branch we're handling a type variable, like 'a in option<'a> *)
     ( (match doEncode with
-      | true -> Some (makeIdentExpr (encoderVarPrefix ^ s)) [@explicit_arity]
+      | true -> Some (makeIdentExpr (encoderVarPrefix ^ s))
       | false -> None),
       match doDecode with
-      | true -> Some (makeIdentExpr (decoderVarPrefix ^ s)) [@explicit_arity]
+      | true -> Some (makeIdentExpr (decoderVarPrefix ^ s))
       | false -> None )
-  | ((Ptyp_constr (constr, typeArgs)) [@explicit_arity]) -> (
+  | Ptyp_constr (constr, typeArgs) -> (
+    (* Here we're handling a type constructor. This might be a type constructor with
+       a name, like `type blah = string`, or it might be a nameless type constructor,
+       like `string`, or `pizza`. When you read "constructor" here, don't think
+       of only a type definition, but think of any time a type is mentioned at all,
+       syntactically, mentioning a type is "constructing" that type. *)
     let customCodec = getAttributeByName ptyp_attributes "decco.codec" in
     let encode, decode =
       match customCodec with
-      | ((Ok None) [@explicit_arity]) ->
-        generateConstrCodecs encodeDecodeFlags constr
-      | ((Ok ((Some attribute) [@explicit_arity])) [@explicit_arity]) -> (
-        let expr = getExpressionFromPayload attribute in
-        ( (match doEncode with
-          | true ->
-            Some
-              [%expr
-                let e, _ = [%e expr] in
-                e]
-            [@explicit_arity]
-          | false -> None),
-          match doDecode with
-          | true ->
-            Some
-              [%expr
-                let _, d = [%e expr] in
-                d]
-            [@explicit_arity]
-          | false -> None ))
-      | ((Error s) [@explicit_arity]) -> fail ptyp_loc s
+      (* Shortcut! We're handling a type where the user has specified their own
+         codec functions. Just return their settings instead of generating more
+         of our own. *)
+      | Ok (Some attribute) -> generateCustomCodecs attribute encodeDecodeFlags
+      (* Hey! 👉 This is the most common branch. We're going to go generate codecs here based
+         on the type constructor we're handling 👈 *)
+      | Ok None -> generateCodecsFromTypeConstructor encodeDecodeFlags constr
+      (* Arg, we couldn't even see if there was a custom codec to handle because
+         of some unexpected error. *)
+      | Error s -> fail ptyp_loc s
     in
     match List.length typeArgs = 0 with
-    | true -> (encode, decode)
-    | false -> parameterizeCodecs typeArgs encode decode encodeDecodeFlags)
+    | true ->
+      (* We've got a simple type here with no parameters! Just return the functions
+         generated above *)
+      (encode, decode)
+    | false ->
+      (* Looks like there are some params for this type. Let's handle
+         those now. *)
+      parameterizeCodecs typeArgs encode decode encodeDecodeFlags)
   | _ -> fail ptyp_loc "This syntax is not yet handled by decco"

--- a/ppx_src/src/Records.ml
+++ b/ppx_src/src/Records.ml
@@ -97,7 +97,7 @@ let generateDecoder decls unboxed =
           [%e generateNestedSwitches decls]
         | _ -> Decco.error "Not an object" v]
 
-let parseDecl generatorSettings
+let parseDecl encodeDecodeFlags
     {pld_name = {txt}; pld_loc; pld_type; pld_attributes} =
   let default =
     match getAttributeByName pld_attributes "decco.default" with
@@ -118,12 +118,12 @@ let parseDecl generatorSettings
     name = txt;
     key;
     field = Exp.field [%expr v] (lid txt);
-    codecs = Codecs.generateCodecs generatorSettings pld_type;
+    codecs = Codecs.generateCodecs encodeDecodeFlags pld_type;
     default;
   }
 
-let generateCodecs ({doEncode; doDecode} as generatorSettings) decls unboxed =
-  let parsedDecls = List.map (parseDecl generatorSettings) decls in
+let generateCodecs ({doEncode; doDecode} as encodeDecodeFlags) decls unboxed =
+  let parsedDecls = List.map (parseDecl encodeDecodeFlags) decls in
   ( (match doEncode with
     | true -> Some (generateEncoder parsedDecls unboxed) [@explicit_arity]
     | false -> None),

--- a/ppx_src/src/Signature.ml
+++ b/ppx_src/src/Signature.ml
@@ -63,11 +63,11 @@ let mapTypeDecl decl =
       =
     decl
   in
-  match getGeneratorSettingsFromAttributes ptype_attributes with
+  match makeEncodeDecodeFlagsFromDecoratorAttributes ptype_attributes with
   | Error s -> fail ptype_loc s
   | Ok None -> []
-  | Ok (Some generatorSettings) ->
-    generateSigDecls generatorSettings typeName (getParamNames ptype_params)
+  | Ok (Some encodeDecodeFlags) ->
+    generateSigDecls encodeDecodeFlags typeName (getParamNames ptype_params)
 
 let mapSignatureItem mapper ({psig_desc} as signatureItem) =
   match psig_desc with

--- a/ppx_src/src/Structure.ml
+++ b/ppx_src/src/Structure.ml
@@ -3,11 +3,6 @@ open Parsetree
 open Ast_helper
 open Utils
 
-type typeInfo = {typeName: label; typeParams: label list}
-
-let typeNameAndParamsToTypeDeclaration {typeName; typeParams} =
-  Typ.constr (lid typeName) (List.map (fun s -> Typ.var s) typeParams)
-
 let jsJsonTypeDecl = Typ.constr (lid "Js.Json.t") []
 
 let buildRightHandSideOfEqualSignForCodecDeclarations (paramNames : label list)

--- a/ppx_src/src/Utils.ml
+++ b/ppx_src/src/Utils.ml
@@ -138,3 +138,8 @@ let print_strings strings =
   Printf.printf "[%s]\n" formatted
 
 let labelToCoreType label = Ast_helper.Typ.constr (lid label) []
+
+type typeInfo = {typeName: label; typeParams: label list}
+
+let typeNameAndParamsToTypeDeclaration {typeName; typeParams} =
+  Typ.constr (lid typeName) (List.map (fun s -> Typ.var s) typeParams)

--- a/ppx_src/src/Utils.ml
+++ b/ppx_src/src/Utils.ml
@@ -22,6 +22,9 @@ let mknoloc txt = mkloc txt Location.none
 
 let lid ?(loc = Location.none) s = mkloc (Longident.parse s) loc
 
+(* Turn a label into an identifier, where an identifier is something like
+   x, or M.x: https://v2.ocaml.org/releases/5.1/api/compilerlibref/Parsetree.html#1_Corelanguage
+*)
 let makeIdentExpr s = Exp.ident (mknoloc (longidentParse s))
 
 let tupleOrSingleton tuple l =

--- a/src/Decco.res
+++ b/src/Decco.res
@@ -14,7 +14,7 @@ let error = (~path=?, message, value) => {
   | None => ""
   | Some(s) => s
   }
-  Belt.Result.Error({path: path, message: message, value: value})
+  Belt.Result.Error({path, message, value})
 }
 
 let stringToJson = s => Js.Json.string(s)
@@ -24,7 +24,7 @@ let stringFromJson = j =>
   | None => Belt.Result.Error({path: "", message: "Not a string", value: j})
   }
 
-let intToJson = i => i |> float_of_int |> Js.Json.number
+let intToJson = i => Js.Json.number(float_of_int(i))
 let intFromJson = j =>
   switch Js.Json.decodeNumber(j) {
   | Some(f) =>
@@ -35,7 +35,7 @@ let intFromJson = j =>
   | _ => Belt.Result.Error({path: "", message: "Not a number", value: j})
   }
 
-let int64ToJson = i => i |> Int64.float_of_bits |> Js.Json.number
+let int64ToJson = i => Js.Json.number(Int64.float_of_bits(i))
 
 let int64FromJson = j =>
   switch Js.Json.decodeNumber(j) {
@@ -43,7 +43,7 @@ let int64FromJson = j =>
   | None => error("Not a number", j)
   }
 
-let int64ToJsonUnsafe = i => i |> Int64.to_float |> Js.Json.number
+let int64ToJsonUnsafe = i => Js.Json.number(Int64.to_float(i))
 
 let int64FromJsonUnsafe = j =>
   switch Js.Json.decodeNumber(j) {
@@ -51,14 +51,14 @@ let int64FromJsonUnsafe = j =>
   | None => error("Not a number", j)
   }
 
-let floatToJson = v => v |> Js.Json.number
+let floatToJson = v => Js.Json.number(v)
 let floatFromJson = j =>
   switch Js.Json.decodeNumber(j) {
   | Some(f) => Belt.Result.Ok(f)
   | None => Belt.Result.Error({path: "", message: "Not a number", value: j})
   }
 
-let boolToJson = v => v |> Js.Json.boolean
+let boolToJson = v => Js.Json.boolean(v)
 let boolFromJson = j =>
   switch Js.Json.decodeBoolean(j) {
   | Some(b) => Belt.Result.Ok(b)
@@ -68,7 +68,7 @@ let boolFromJson = j =>
 let unitToJson = () => Js.Json.number(0.0)
 let unitFromJson = _ => Belt.Result.Ok()
 
-let arrayToJson = (encoder, arr) => arr |> Js.Array.map(encoder) |> Js.Json.array
+let arrayToJson = (encoder, arr) => Js.Json.array(Js.Array.map(encoder, arr))
 
 let arrayFromJson = (decoder, json) =>
   switch Js.Json.decodeArray(json) {
@@ -87,10 +87,10 @@ let arrayFromJson = (decoder, json) =>
   | None => Belt.Result.Error({path: "", message: "Not an array", value: json})
   }
 
-let listToJson = (encoder, list) => list |> Array.of_list |> arrayToJson(encoder)
+let listToJson = (encoder, list) => arrayToJson(encoder, Array.of_list(list))
 
 let listFromJson = (decoder, json) =>
-  json |> arrayFromJson(decoder) |> Belt.Result.map(_, Array.to_list)
+  (Belt.Result.map(_, Array.to_list))(arrayFromJson(decoder, json))
 
 let optionToJson = (encoder, opt) =>
   switch opt {
@@ -99,16 +99,18 @@ let optionToJson = (encoder, opt) =>
   }
 
 let optionFromJson = (decoder, json) =>
-  switch Js.Null_undefined.return(json) |> Js.Null_undefined.toOption {
+  switch Js.Null_undefined.toOption(Js.Null_undefined.return(json)) {
   | None => Belt.Result.Ok(None)
-  | Some(json) => decoder(json) |> Belt.Result.map(_, v => Some(v))
+  | Some(json) => (Belt.Result.map(_, v => Some(v)))(decoder(json))
   }
 
 let resultToJson = (okEncoder, errorEncoder, result) =>
-  switch result {
-  | Belt.Result.Ok(v) => [Js.Json.string("Ok"), okEncoder(v)]
-  | Belt.Result.Error(e) => [Js.Json.string("Error"), errorEncoder(e)]
-  } |> Js.Json.array
+  Js.Json.array(
+    switch result {
+    | Belt.Result.Ok(v) => [Js.Json.string("Ok"), okEncoder(v)]
+    | Belt.Result.Error(e) => [Js.Json.string("Error"), errorEncoder(e)]
+    },
+  )
 
 let resultFromJson = (okDecoder, errorDecoder, json) =>
   switch Js.Json.decodeArray(json) {
@@ -129,7 +131,7 @@ let resultFromJson = (okDecoder, errorDecoder, json) =>
   | None => error("Not an array", json)
   }
 
-let dictToJson = (encoder, dict) => dict->Js.Dict.map((. a) => encoder(a), _)->Js.Json.object_
+let dictToJson = (encoder, dict) => dict->Js.Dict.map(a => encoder(a), _)->Js.Json.object_
 
 let dictFromJson = (decoder, json) =>
   switch Js.Json.decodeObject(json) {
@@ -149,6 +151,16 @@ let dictFromJson = (decoder, json) =>
     )
   | None => Error({path: "", message: "Not a dict", value: json})
   }
+
+/**
+  * Merges two JSON objects together. If there are any duplicate keys, the value from the second object will be used.
+  * This function is type-unsafe and should be used with caution. It's here to be used by generated decoder
+  * functions for records that use spreads in their types, and these functions are careful only to pass in
+  * JSON objects and not other kinds of values.
+ */
+let unsafeMergeJsonObjects = (a: Js.Json.t, b: Js.Json.t): Js.Json.t => {
+  Js.Obj.assign(a->Obj.magic, b->Obj.magic)->Obj.magic
+}
 
 module Codecs = {
   include Decco_Codecs

--- a/src/Decco.res
+++ b/src/Decco.res
@@ -158,7 +158,7 @@ let dictFromJson = (decoder, json) =>
   * functions for records that use spreads in their types, and these functions are careful only to pass in
   * JSON objects and not other kinds of values.
  */
-let unsafeMergeJsonObjects = (a: Js.Json.t, b: Js.Json.t): Js.Json.t => {
+let unsafeMergeJsonObjectsCurried = (a: Js.Json.t) => (b: Js.Json.t): Js.Json.t => {
   Js.Obj.assign(a->Obj.magic, b->Obj.magic)->Obj.magic
 }
 

--- a/src/Decco.res
+++ b/src/Decco.res
@@ -158,8 +158,11 @@ let dictFromJson = (decoder, json) =>
   * functions for records that use spreads in their types, and these functions are careful only to pass in
   * objects and not other kinds of values.
  */
-let unsafeMergeObjects = (a: 'a, b: 'b): 'c => {
+let unsafeMergeObjectsCurried = (a: 'a) => (b: 'b): 'c => {
   Js.Obj.assign(a->Obj.magic, b->Obj.magic)->Obj.magic
+}
+let unsafeMergeObjects = (a: 'a, b: 'b): 'c => {
+  unsafeMergeObjectsCurried(a)(b)
 }
 
 /**

--- a/src/Decco.res
+++ b/src/Decco.res
@@ -153,13 +153,22 @@ let dictFromJson = (decoder, json) =>
   }
 
 /**
-  * Merges two JSON objects together. If there are any duplicate keys, the value from the second object will be used.
+  * Merges two javascript objects together. If there are any duplicate keys, the value from the second object will be used.
   * This function is type-unsafe and should be used with caution. It's here to be used by generated decoder
   * functions for records that use spreads in their types, and these functions are careful only to pass in
-  * JSON objects and not other kinds of values.
+  * objects and not other kinds of values.
  */
-let unsafeMergeJsonObjectsCurried = (a: Js.Json.t) => (b: Js.Json.t): Js.Json.t => {
+let unsafeMergeObjects = (a: 'a, b: 'b): 'c => {
   Js.Obj.assign(a->Obj.magic, b->Obj.magic)->Obj.magic
+}
+
+/**
+  * Adds a field to a javascript object. This function is type-unsafe and should be used with caution. It's here to be used by
+  * generated decoder functions for records that use spreads in their types, and these functions are careful only to pass in
+  * objects and not other kinds of values.
+ */
+let unsafeAddFieldToObject = (key: string, value: 'b, obj: 'a): 'c => {
+  Obj.magic(obj)->Js.Dict.set(key, value)->Obj.magic
 }
 
 module Codecs = {

--- a/test/__tests__/CustomCodecs.res
+++ b/test/__tests__/CustomCodecs.res
@@ -20,6 +20,6 @@ describe("CustomCodecs", () => {
   test("should decode", () => {
     let encoded = "42"->Decco.stringToJson
     let decoded = intAsStr_decode(encoded)
-    expect(decoded)->toBe(Ok(42))
+    expect(decoded)->toEqual(Ok(42))
   })
 })

--- a/test/__tests__/CustomCodecs.res
+++ b/test/__tests__/CustomCodecs.res
@@ -4,8 +4,8 @@
 open Jest
 open Expect
 
-let intToStr = (i: int) => i->string_of_int
-let intFromStr = (s: string) => s->int_of_string
+let intToStr = (i: int) => i->string_of_int->Decco.stringToJson
+let intFromStr = (s: Js.Json.t) => s->Decco.stringFromJson->Belt.Result.map(int_of_string)
 
 @decco type intAsStr = @decco.codec((intToStr, intFromStr)) int
 
@@ -14,12 +14,12 @@ describe("CustomCodecs", () => {
     let x: intAsStr = 42
 
     let encoded = x->intAsStr_encode
-    expect(encoded)->toBe("42")
+    expect(encoded)->toBe("42"->Decco.stringToJson)
   })
 
   test("should decode", () => {
-    let encoded = "42"
+    let encoded = "42"->Decco.stringToJson
     let decoded = intAsStr_decode(encoded)
-    expect(decoded)->toBe(42)
+    expect(decoded)->toBe(Ok(42))
   })
 })

--- a/test/__tests__/Foo.res
+++ b/test/__tests__/Foo.res
@@ -1,0 +1,5 @@
+@decco.decode
+type a = {first_name: string}
+
+@decco.decode
+type b = {...a, last_name: string}

--- a/test/__tests__/RecordSpreads.res
+++ b/test/__tests__/RecordSpreads.res
@@ -1,0 +1,51 @@
+open Jest
+open TestUtils
+open Expect
+
+module A = {
+  @decco
+  type t = {first_name: string}
+}
+
+module B = {
+  @decco
+  type t = {last_name: string}
+}
+
+module C = {
+  @decco
+  type t = {
+    ...A.t,
+    ...B.t,
+    age: int,
+  }
+}
+
+// describe("record spreading", () => {
+//   test("should encode", () => {
+//     let a = {
+//       first_name: "Bob",
+//     }
+
+//     let b = {
+//       last_name: "pizza",
+//     }
+
+//     let c: c = {
+//       first_name: "bob",
+//       last_name: "pizza",
+//       age: 3,
+//     }
+
+//     let encoded = c_encode(c)
+
+//     // expect("123")->toBe(Js.Json.stringify(c_encode(c)))
+//     expect("123")->toBe("123")
+//   })
+
+//   // test("should decode", () => {
+//   //   let encoded = "42"
+//   //   let decoded = intAsStr_decode(encoded)
+//   //   expect(decoded)->toBe(42)
+//   // })
+// })

--- a/test/__tests__/RecordSpreads.res
+++ b/test/__tests__/RecordSpreads.res
@@ -6,40 +6,44 @@ module A = {
   type t = {first_name: string}
   @decco
   type b = {last_name: string}
+  module Nested = {
+    @decco
+    type t = {pizza: string}
+  }
 }
 
-module C = {
-  @decco
-  type t = {
-    ...A.t,
-    ...A.b,
-    age: int,
-  }
+@decco
+type t = {
+  ...A.t,
+  ...A.b,
+  ...A.Nested.t,
+  age: int,
 }
 
 describe("record spreading", () => {
   test("should encode", () => {
-    let c: C.t = {
+    let v: t = {
       first_name: "bob",
       last_name: "pizza",
       age: 3,
+      pizza: "pie",
     }
 
-    let encoded = C.t_encode(c)
+    let encoded = t_encode(v)
 
     expect(Js.Json.stringify(encoded))->toBe(
-      {"first_name": "bob", "last_name": "pizza", "age": 3}
+      {"first_name": "bob", "last_name": "pizza", "pizza": "pie", "age": 3}
       ->Obj.magic
       ->Js.Json.stringify,
     )
   })
 
   test("should decode", () => {
-    let json = Js.Json.parseExn(`{"first_name":"bob","last_name":"pizza","age":3}`)
-    let decoded = C.t_decode(json)
+    let json = Js.Json.parseExn(`{"first_name":"bob","last_name":"pizza","age":3, "pizza": "pie"}`)
+    let decoded = t_decode(json)
 
-    expect(decoded->Belt.Result.map(x => (x.first_name, x.last_name, x.age)))->toEqual(
-      Ok(("bob", "pizza", 3)),
+    expect(decoded->Belt.Result.map(x => (x.first_name, x.last_name, x.age, x.pizza)))->toEqual(
+      Ok(("bob", "pizza", 3, "pie")),
     )
   })
 })

--- a/test/__tests__/RecordSpreads.res
+++ b/test/__tests__/RecordSpreads.res
@@ -1,52 +1,45 @@
-// open Jest
-// open TestUtils
-// open Expect
+open Jest
+open Expect
 
-// module A = {
-//   @decco
-//   type t = {first_name: string}
-// }
+module A = {
+  @decco
+  type t = {first_name: string}
+  @decco
+  type b = {last_name: string}
+}
 
-// module B = {
-//   @decco
-//   type t = {last_name: string}
-// }
+module C = {
+  @decco
+  type t = {
+    ...A.t,
+    ...A.b,
+    age: int,
+  }
+}
 
-// module C = {
-//   @decco
-//   type t = {
-//     ...A.t,
-//     ...B.t,
-//     age: int,
-//   }
-// }
+describe("record spreading", () => {
+  test("should encode", () => {
+    let c: C.t = {
+      first_name: "bob",
+      last_name: "pizza",
+      age: 3,
+    }
 
-// describe("record spreading", () => {
-//   test("should encode", () => {
-//     let a = {
-//       first_name: "Bob",
-//     }
+    let encoded = C.t_encode(c)
 
-//     let b = {
-//       last_name: "pizza",
-//     }
+    expect(Js.Json.stringify(encoded))->toBe(
+      {"first_name": "bob", "last_name": "pizza", "age": 3}
+      ->Obj.magic
+      ->Js.Json.stringify,
+    )
+  })
 
-//     let c: c = {
-//       first_name: "bob",
-//       last_name: "pizza",
-//       age: 3,
-//     }
+  test("should decode", () => {
+    let json = Js.Json.parseExn(`{"first_name":"bob","last_name":"pizza","age":3}`)
+    let decoded = C.t_decode(json)
 
-//     let encoded = c_encode(c)
-
-//     // expect("123")->toBe(Js.Json.stringify(c_encode(c)))
-//     expect("123")->toBe("123")
-//   })
-
-//   // test("should decode", () => {
-//   //   let encoded = "42"
-//   //   let decoded = intAsStr_decode(encoded)
-//   //   expect(decoded)->toBe(42)
-//   // })
-// })
-
+    expect(decoded->Belt.Result.map(x => (x.first_name, x.last_name, x.age)))->toEqual(
+      Ok(("bob", "pizza", 3)),
+    )
+  })
+})

--- a/test/__tests__/RecordSpreads.res
+++ b/test/__tests__/RecordSpreads.res
@@ -1,25 +1,25 @@
-open Jest
-open TestUtils
-open Expect
+// open Jest
+// open TestUtils
+// open Expect
 
-module A = {
-  @decco
-  type t = {first_name: string}
-}
+// module A = {
+//   @decco
+//   type t = {first_name: string}
+// }
 
-module B = {
-  @decco
-  type t = {last_name: string}
-}
+// module B = {
+//   @decco
+//   type t = {last_name: string}
+// }
 
-module C = {
-  @decco
-  type t = {
-    ...A.t,
-    ...B.t,
-    age: int,
-  }
-}
+// module C = {
+//   @decco
+//   type t = {
+//     ...A.t,
+//     ...B.t,
+//     age: int,
+//   }
+// }
 
 // describe("record spreading", () => {
 //   test("should encode", () => {
@@ -49,3 +49,4 @@ module C = {
 //   //   expect(decoded)->toBe(42)
 //   // })
 // })
+


### PR DESCRIPTION
Encoders & decoders are supported. Spreading multiple types is supported.

One possible breaking change is that this add explicit type signatures to codec functions. So where it used to be possible to use @decco.codec to assign a function that would encode/decode to anything, not just JSON, now JSON is specified as the target type for all codecs.